### PR TITLE
Fix forward in HFCrossScorer

### DIFF
--- a/src/xpmir/experiments/ir.py
+++ b/src/xpmir/experiments/ir.py
@@ -129,7 +129,10 @@ class IRExperimentHelper(LearningExperimentHelper):
                 print(df)  # noqa: T201
 
                 # And save them
+
                 csv_path = self.xp.resultspath / "results.csv"
+                if not self.xp.resultspath.exists():
+                    self.xp.resultspath.mkdir(parents=True, exist_ok=True)
                 logging.info(f"Saved results in {csv_path.absolute()}")
                 with csv_path.open("wt") as fp:
                     df.to_csv(fp, index=False)

--- a/src/xpmir/neural/huggingface.py
+++ b/src/xpmir/neural/huggingface.py
@@ -72,7 +72,7 @@ class HFCrossScorer(LearnableScorer, DistributableModel):
         # strange that some existing models on the huggingface don't use the token_type
         with torch.set_grad_enabled(torch.is_grad_enabled()):
             result = self.model(
-                tokenized.ids, attention_mask=tokenized.mask.to(self.device)
+                tokenized.ids, token_type_ids=tokenized.token_type_ids.to(self.device), attention_mask=tokenized.mask.to(self.device)
             ).logits  # Tensor[float] of length records size
         return result
 


### PR DESCRIPTION
I've noticed a huge difference in scores between the previous forward (without the `token_type_ids`) and the proposed fix (with `token_type_ids`). From my small samples of test, I believe the second version is the right one or at least the one which produces the scores closest to what one would get with the same cross-encoder through HF.