### PR TITLE
Infer `max_tokens` from the model config and not from the tokenizer config

### DIFF
--- a/src/xpmir/text/huggingface/__init__.py
+++ b/src/xpmir/text/huggingface/__init__.py
@@ -181,7 +181,11 @@ class BaseTransformer(Encoder):
         return self.tokenizer._tokenizer.get_vocab_size()
 
     def maxtokens(self) -> int:
-        return self.config.max_position_embeddings
+        try:
+            return self.tokenizer.max_model_length
+        except:
+            logging.info("No `max_model_length` in the tokenizer, defaulting to `model.config.max_position_embeddings` instead")
+            return self.config.max_position_embeddings
 
     def dim(self):
         return self.config.hidden_size


### PR DESCRIPTION
Following a bug I encountered with the model `microsoft/MiniLM-L12-H384-uncased` who has an empty dictionary for its tokenizer config, I propose to return `tokenizer.max_model_length` for `maxtokens` if it exists, and to default to `model.config.max_position_embeddings` otherwise.

I thought about always returning `max_position_embeddings` but it seems that in nature, the two are not exactly the same thing so perhaps it is best to limit its usage.