### PR TITLE
Fix test_forward and uniformize DualTransformerEncoder with other Encoders

### DIFF
--- a/src/xpmir/neural/__init__.py
+++ b/src/xpmir/neural/__init__.py
@@ -37,10 +37,10 @@ class DualRepresentationScorer(LearnableScorer, Generic[QueriesRep, DocsRep]):
         q_ix, d_ix = pairs
         return self.score_pairs(
             enc_queries[
-                q_ix,
+                q_ix
             ],
             enc_documents[
-                d_ix,
+                d_ix
             ],
             info,
         ).flatten()

--- a/src/xpmir/neural/cross.py
+++ b/src/xpmir/neural/cross.py
@@ -53,9 +53,9 @@ class CrossScorer(LearnableScorer, DistributableModel):
                 (tr[TextItem].text, dr[TextItem].text)
                 for tr, dr in zip(inputs.topics, inputs.documents)
             ],
-            options=self.tokenizer_options,
+            # options=self.tokenizer_options,
         )  # shape (batch_size * dimension)
-        return self.classifier(pairs.value).squeeze(1)
+        return self.classifier(pairs).squeeze(1)
 
     def distribute_models(self, update):
         self.encoder = update(self.encoder)

--- a/src/xpmir/neural/cross.py
+++ b/src/xpmir/neural/cross.py
@@ -55,7 +55,7 @@ class CrossScorer(LearnableScorer, DistributableModel):
             ],
             # options=self.tokenizer_options,
         )  # shape (batch_size * dimension)
-        return self.classifier(pairs).squeeze(1)
+        return self.classifier(pairs.value).squeeze(1)
 
     def distribute_models(self, update):
         self.encoder = update(self.encoder)

--- a/src/xpmir/neural/dual.py
+++ b/src/xpmir/neural/dual.py
@@ -106,11 +106,13 @@ class CosineDense(Dense):
 
     def encode_queries(self, records: List[TopicRecord]):
         queries = (self.query_encoder or self.encoder)(records)
-        return queries / queries.norm(dim=1, keepdim=True)
+        queries.value /= queries.value.norm(dim=1, keepdim=True)
+        return queries
 
     def encode_documents(self, records: List[DocumentRecord]):
         documents = self.encoder(records)
-        return documents / documents.norm(dim=1, keepdim=True)
+        documents.value /= documents.value.norm(dim=1, keepdim=True)
+        return documents
 
 
 class DotDense(Dense):

--- a/src/xpmir/test/neural/test_forward.py
+++ b/src/xpmir/test/neural/test_forward.py
@@ -160,7 +160,7 @@ def cross_scorer():
     """Cross-scorer classifier factory"""
     from xpmir.neural.cross import CrossScorer
 
-    return CrossScorer(encoder=DummyDualTextEncoder()).instance()
+    return CrossScorer(max_length=100, encoder=DummyDualTextEncoder()).instance()
 
 
 # ---

--- a/src/xpmir/text/adapters.py
+++ b/src/xpmir/text/adapters.py
@@ -24,9 +24,11 @@ class MeanTextEncoder(TokenizedTextEncoderBase[InputType, RepresentationOutput])
         return self.encoder.dimension
 
     def forward(self, texts: List[InputType], options=None) -> RepresentationOutput:
-        emb_texts = self.encoder(texts, options=options)
+        # emb_texts = self.encoder(texts, options=options)
+        emb_texts = self.encoder([record[TextItem].text for record in texts], options=options)
         # Computes the mean over the time dimension (vocab output is batch x time x dim)
-        return emb_texts.value.mean(1)
+        emb_texts.value = emb_texts.value.mean(1)
+        return emb_texts
 
 
 class TopicTextConverter(Converter[Record, str]):

--- a/src/xpmir/text/encoders.py
+++ b/src/xpmir/text/encoders.py
@@ -192,6 +192,9 @@ class TokensRepresentationOutput(RepresentationOutput):
     tokenized: TokenizedTexts
     """Tokenized texts"""
 
+    def __getitem__(self, ix: Union[slice, int]):
+        return self.__class__(self.value[ix], self.tokenized[ix])
+
 
 @define
 class TextsRepresentationOutput(RepresentationOutput):

--- a/src/xpmir/text/huggingface/__init__.py
+++ b/src/xpmir/text/huggingface/__init__.py
@@ -184,7 +184,7 @@ class BaseTransformer(Encoder):
         try:
             return self.tokenizer.max_model_length
         except:
-            logging.info("No `max_model_length` in the tokenizer, defaulting to `model.config.max_position_embeddings` instead")
+            logging.warning("No `max_model_length` in the tokenizer, defaulting to `model.config.max_position_embeddings` instead")
             return self.config.max_position_embeddings
 
     def dim(self):

--- a/src/xpmir/text/huggingface/__init__.py
+++ b/src/xpmir/text/huggingface/__init__.py
@@ -16,6 +16,8 @@ from xpmir.text.encoders import (
     DualTextEncoder,
     TextEncoder,
     TripletTextEncoder,
+    EncoderOutput,
+    RepresentationOutput
 )
 from xpmir.utils.utils import easylog
 from xpmir.learning.context import TrainerContext, TrainState
@@ -361,7 +363,7 @@ class DualTransformerEncoder(BaseTransformer, DualTextEncoder):
 
     version: Constant[int] = 2
 
-    def forward(self, texts: List[Tuple[str, str]]):
+    def forward(self, texts: List[Tuple[str, str]])->EncoderOutput:
         tokenized = self.batch_tokenize(
             texts, 
             maxlen=self.maxlen if self.maxlen is not None else self.maxtokens(), 
@@ -378,7 +380,7 @@ class DualTransformerEncoder(BaseTransformer, DualTextEncoder):
             )
 
         # Assumes that [CLS] is the first token
-        return y.last_hidden_state[:, 0]
+        return RepresentationOutput(y.last_hidden_state[:, 0])
 
     @property
     def dimension(self) -> int:

--- a/src/xpmir/text/tokenizers.py
+++ b/src/xpmir/text/tokenizers.py
@@ -36,9 +36,9 @@ class TokenizedTexts(NamedTuple):
 
     def __getitem__(self, ix):
         return TokenizedTexts(
-            opt_slice(self.tokens, ix),
+            [opt_slice(self.tokens, i) for i in ix],
             self.ids[ix],
-            self.lens[ix],
+            [self.lens[i] for i in ix],
             opt_slice(self.mask, ix),
             opt_slice(self.token_type_ids, ix),
         )


### PR DESCRIPTION
I have proposed different fixes to make the tests in the file `test_forward.py` work. Following this, I have also proposed to uniformize what's returned by the `DualTransformerEncoder` forward method with other `Encoder` classes, ie. to be an `EncoderOutput`. If accepted, it might be necessary to do the same changes for the other classes inheriting both from `BaseTransformer` and `DualTextEncoder` as they all returned Tensor which might be the root problem for many downstream issues when used as the encoder of `CrossScorer`.